### PR TITLE
Fix socket init resource leak

### DIFF
--- a/fuzz_socket_prog.cc
+++ b/fuzz_socket_prog.cc
@@ -39,6 +39,7 @@ static void apply_InitSection(const Header& init) {
             PyObject* sock = PyObject_CallMethod(socket_class, "fromfd", "iii",
                 fd[0], sock_init.family(), sock_init.type());
             Py_DECREF(socket_class);
+            close(fd[0]);
             if (sock) {
                 socket_pool[sock_init.id()] = sock;
                 if (!sock_init.preload_send().empty()) {


### PR DESCRIPTION
## Summary
- close fromfd file descriptor after duplication

## Testing
- `bash build.sh` *(fails: socket_api.proto: Expected top-level statement)*

------
https://chatgpt.com/codex/tasks/task_e_685ff9df30708331a5675ca8ba7b4129