### PR TITLE
Use local python-config path

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -15,7 +15,7 @@ echo "Generating protobuf files..."
 protoc --cpp_out=. socket_api.proto
 
 # Get Python config
-PYTHON_CONFIG="python3.9-config"
+PYTHON_CONFIG="buildroot/usr/bin/python3.9-config"
 PYTHON_CFLAGS=$($PYTHON_CONFIG --cflags)
 PYTHON_LDFLAGS=$($PYTHON_CONFIG --ldflags --embed)
 


### PR DESCRIPTION
## Summary
- use the bundled `buildroot/usr/bin/python3.9-config` when computing Python build flags

## Testing
- `bash -n build.sh`


------
https://chatgpt.com/codex/tasks/task_e_6860011a8f44833199afd98033cf88af