### PR TITLE
Update build.sh for bundled python

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -14,10 +14,10 @@ $CC -fPIC -shared -o wrap_net.so wrap_net.c -ldl
 echo "Generating protobuf files..."
 protoc --cpp_out=. socket_api.proto
 
-# Get Python config
-PYTHON_CONFIG="buildroot/usr/bin/python3.9-config"
-PYTHON_CFLAGS=$($PYTHON_CONFIG --cflags)
-PYTHON_LDFLAGS=$($PYTHON_CONFIG --ldflags --embed)
+# Get Python config using bundled interpreter
+PYTHON_CONFIG="buildroot/usr/bin/python3.9 buildroot/usr/lib64/python3.9/config-3.9-x86_64-linux-gnu/python-config.py"
+PYTHON_CFLAGS=$(ASAN_OPTIONS=detect_leaks=0 $PYTHON_CONFIG --cflags)
+PYTHON_LDFLAGS=$(ASAN_OPTIONS=detect_leaks=0 $PYTHON_CONFIG --ldflags --embed)
 
 # Build fuzzer
 echo "Building fuzzer..."


### PR DESCRIPTION
## Summary
- use bundled Python `python-config.py`
- disable ASAN leak checks while collecting Python build flags

## Testing
- `bash build.sh` *(fails: libprotobuf-mutator and protobuf headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_6860058ed26083319c8ef647b00a8856