### PR TITLE
Add run script and URL fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This installs headers and libraries under `/usr/local`.
 Clone this repository and run the build script:
 
 ```bash
-git clone https://example.com/fuzz_socketmodule.git
+git clone https://github.com/zef2f/fuzz_socketmodule.git
 cd fuzz_socketmodule
 ./build.sh
 ```
@@ -47,6 +47,12 @@ Use the provided wrapper to intercept networking calls:
 
 ```bash
 LD_PRELOAD=./wrap_net.so ./fuzz_socket -max_len=512 corpus/
+```
+
+For convenience you can also run:
+
+```bash
+./run_fuzzer.sh
 ```
 
 See the `build.sh` script for additional instructions on coverage analysis and seed corpus contents.

--- a/run_fuzzer.sh
+++ b/run_fuzzer.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Simple script to run the fuzzer with the networking wrapper
+set -euo pipefail
+LD_PRELOAD=./wrap_net.so ./fuzz_socket -max_len=512 corpus/


### PR DESCRIPTION
## Summary
- fix the README clone URL
- document a helper script for running the fuzzer
- add `run_fuzzer.sh` helper script

## Testing
- `shellcheck run_fuzzer.sh`
- `./run_fuzzer.sh` *(fails: `./fuzz_socket` missing)*

------
https://chatgpt.com/codex/tasks/task_e_686008973028833186c171b113f04687