### PR TITLE
Improve fuzzer docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,15 @@ Use the provided wrapper to intercept networking calls:
 LD_PRELOAD=./wrap_net.so ./fuzz_socket -max_len=512 corpus/
 ```
 
+Leak detection in AddressSanitizer can produce a lot of noise when fuzzing
+Python's socket module. The build script already disables leak checking, but the
+runtime environment must also turn it off. Set the `ASAN_OPTIONS` environment
+variable when launching the fuzzer:
+
+```bash
+ASAN_OPTIONS=detect_leaks=0 LD_PRELOAD=./wrap_net.so ./fuzz_socket -max_len=512 corpus/
+```
+
 If you just want to confirm that the harness runs, execute it for a few seconds
 using `timeout`:
 


### PR DESCRIPTION
## Summary
- clarify how to disable leak detection when running the fuzzer

## Testing
- `ASAN_OPTIONS=detect_leaks=0 LD_PRELOAD=./wrap_net.so ./fuzz_socket -runs=1 corpus/`
- `timeout 5s bash -c 'ASAN_OPTIONS=detect_leaks=0 LD_PRELOAD=./wrap_net.so ./fuzz_socket corpus/'`

------
https://chatgpt.com/codex/tasks/task_e_68602286928883319da022e5b61d568c